### PR TITLE
fixing twitterify filter twitter search link

### DIFF
--- a/wp-content/themes/timber/setup/filter-twitterify.php
+++ b/wp-content/themes/timber/setup/filter-twitterify.php
@@ -7,7 +7,7 @@ function twitterify($ret) {
     $pattern .= '[a-wyz][a-z](fo|g|l|m|mes|o|op|pa|ro|seum|t|u|v|z)?)#i';
     $ret = preg_replace($pattern, '<a href="mailto:\\1">\\1</a>', $ret);
     $ret = preg_replace("/\B@(\w+)/", " <a href=\"http://www.twitter.com/\\1\" target=\"_blank\">@\\1</a>", $ret);
-    $ret = preg_replace("/\B#(\w+)/", " <a href=\"http://search.twitter.com/search?q=\\1\" target=\"_blank\">#\\1</a>", $ret);
+    $ret = preg_replace("/\B#(\w+)/", " <a href=\"http://www.twitter.com/search?q=\\1\" target=\"_blank\">#\\1</a>", $ret);
     return $ret;
 }
 


### PR DESCRIPTION
those jerks at twitter decided it wasn't worth their while to redirect search.twitter.com to www.twitter.com.